### PR TITLE
add parameter "identity" to server.cfg

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #
 class mcollective(
-  Optional[String]                             $identity             = undef,
+  Optional[String]                             $server_identity      = undef,
   String                                       $stomp_host           = 'localhost',
   String                                       $stomp_user           = 'mcollective',
   String                                       $stomp_password       = 'password',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #
 class mcollective(
-  String                                       $identity             = undef,
+  Optional[String]                             $identity             = undef,
   String                                       $stomp_host           = 'localhost',
   String                                       $stomp_user           = 'mcollective',
   String                                       $stomp_password       = 'password',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 #
 class mcollective(
+  String                                       $identity             = undef,
   String                                       $stomp_host           = 'localhost',
   String                                       $stomp_user           = 'mcollective',
   String                                       $stomp_password       = 'password',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,12 +4,13 @@
 #
 #
 class mcollective::server (
-  $stomp_host     = $::mcollective::stomp_host,
-  $stomp_user     = $::mcollective::stomp_user,
-  $stomp_password = $::mcollective::stomp_password,
-  $stomp_port     = $::mcollective::stomp_port,
-  $psk            = $::mcollective::psk,
-  $plugin_config  = $::mcollective::server_plugin_config,
+  $server_identity = $mcollective::server_identity,
+  $stomp_host      = $::mcollective::stomp_host,
+  $stomp_user      = $::mcollective::stomp_user,
+  $stomp_password  = $::mcollective::stomp_password,
+  $stomp_port      = $::mcollective::stomp_port,
+  $psk             = $::mcollective::psk,
+  $plugin_config   = $::mcollective::server_plugin_config,
 ) {
 
   file { '/etc/puppetlabs/mcollective/server.cfg':

--- a/templates/server/server.cfg.erb
+++ b/templates/server/server.cfg.erb
@@ -1,7 +1,7 @@
 # Managed by puppet - do not modify
 
-<% if @identity -%>
-identity = <%= @identity %>
+<% if @server_identity -%>
+identity = <%= @server_identity %>
 <% end -%>
 main_collective = mcollective
 collectives = mcollective

--- a/templates/server/server.cfg.erb
+++ b/templates/server/server.cfg.erb
@@ -1,5 +1,8 @@
 # Managed by puppet - do not modify
 
+<% if @identity -%>
+identity = <%= @identity %>
+<% end -%>
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/puppetlabs/mcollective/plugins:/usr/libexec/mcollective


### PR DESCRIPTION
Hi.
For some operation systems (Ubuntu  for example)  global parameter HOSTNAME, witch is taken from /etc/hostname usually is short name, not FQDN

` man `hostname
FILES
       /etc/hostname Historically this file was supposed to only contain the hostname and not the full canonical FQDN.

For mcollective-server parameter $identity is taken from Ruby’s Socket.gethostname, witch returns short name. Sometimes it is more convenient to use the full name, such as when the server is configured through the Foreman
For resolve this problem I suggest add parameter  'identity' in server.cfg